### PR TITLE
Fix cookie cutter config

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,3 +1,4 @@
 {
-    "project_slug": "django_project"
+    "project_slug": "django_project",
+    "package_description": "A package that does one thing and does it well"
 }


### PR DESCRIPTION
Add package_description to `cookiecutter.json`

#### How to test

Try to run our cookiecutter like described in #15.
* on master, it should fail with `Error message: 'dict object' has no attribute 'package_description'`
* on this branch, it should work.